### PR TITLE
company creation defaults to pending

### DIFF
--- a/spec/requests/api/v1/create_company_spec.rb
+++ b/spec/requests/api/v1/create_company_spec.rb
@@ -12,7 +12,30 @@ RSpec.describe 'CompanyController' do
       expect(Company.count).to eq(1)
       expect(Company.first.name).to eq("Granicus")
     end
+
+    it "creates a company that is pending" do
+      data = { company: {name: "Granicus"}, token: "TurMonLook4"}
+
+      post '/api/v1/companies', params: data
+
+      expect(response).to be_success
+      expect(Company.last.status).to eq('pending')
+
+    end
+
+    it "can't create company without key" do
+      data = { company: {name: "Granicus"} }
+
+      expect(Company.count).to eq(0)
+      post '/api/v1/companies', params: data
+      parsed = JSON.parse(response.body)
+
+
+      expect(response.status).to eq(401)
+      expect(parsed['error']).to eq('unauthorized')
+    end
   end
+
   context 'GET api/v1/company/find' do
     it "can find a company" do
       company = Company.create(name: "Granicus")
@@ -25,6 +48,7 @@ RSpec.describe 'CompanyController' do
       expect(response).to be_success
       expect(parsed['company_id']).to eq(company.id)
     end
+
     it "can't find a non existent company" do
       data = { name: "Granicus" }
 
@@ -33,17 +57,6 @@ RSpec.describe 'CompanyController' do
 
       expect(response.status).to eq(404)
       expect(parsed).to eq("")
-    end
-    it "can't create company without key" do
-      data = { company: {name: "Granicus"} }
-
-      expect(Company.count).to eq(0)
-      post '/api/v1/companies', params: data
-      parsed = JSON.parse(response.body)
-
-
-      expect(response.status).to eq(401)
-      expect(parsed['error']).to eq('unauthorized')
     end
   end
 end


### PR DESCRIPTION
Move existing sad path company creation test to appropriate context and add testing for the verification that a company created on post to api/v1/companies defaults to pending.
@mscherer11 @alishersadikov @Cdunagan05 this picks some low hanging fruit by testing functionality that already exists.